### PR TITLE
exit on error in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,6 @@
+# exit on error
+set -e
+
 # setting conda hook
 eval "$(conda shell.bash hook)"
 # create env


### PR DESCRIPTION
This change makes install.sh exit immediately on critical errors to simplify installation on clean environment.